### PR TITLE
build error

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -19,7 +19,7 @@ FXZ Utils Installation
        2.1. Static vs. dynamic linking of libflzma
        2.2. Optimizing fxzdec and flzmadec
     3. fxzgrep and other scripts
-       3.1. Dependencies
+       3.1. Dependencies 
        3.2. PATH
     4. Troubleshooting
        4.1. "No C99 compiler was found."


### PR DESCRIPTION
fast-lzma2/radix_bitpack.c:16: error: redefinition of typedef 'FL2_matchTable'
fast-lzma2/radix_mf.h:21: note: previous declaration of 'FL2_matchTable' was here

making a bogus PR because issues are disabled